### PR TITLE
Add GitHub action to build and test

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,29 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.8.2'
+        cabal-version: '3.0'
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal install --only-dependencies --enable-tests
+    - name: Build
+      run: |
+        cabal configure --enable-tests
+        cabal build
+    - name: Run tests
+      run: cabal test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,29 +1,129 @@
-name: Haskell CI
+# Haskell stack project Github Actions template
+# https://gist.github.com/mstksg/11f753d891cee5980326a8ea8c865233
+#
+# To use, mainly change the list in 'plans' and modify 'include' for
+# any OS package manager deps.
+#
+# Currently not working for cabal-install >= 3
+#
+# Based on https://raw.githubusercontent.com/commercialhaskell/stack/stable/doc/travis-complex.yml
+#
+# TODO:
+# * cache (https://github.com/actions/cache)
+#     but this is too small. native cacheing will come soon
+#     https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974/highlight/true#M630
+#     so we can wait for then.
+# * support for cabal-install >= 3
+
+name: Haskell Stack Project CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+  - cron: "0 0 * * 1"
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        # use this to specify what resolvers and ghc to use
+        plan:
+        - { build: stack, resolver: "--resolver lts-9"  }    # ghc-8.0.2
+        - { build: stack, resolver: "--resolver lts-11"  }   # ghc-8.2.2
+        - { build: stack, resolver: "--resolver lts-12"  }   # ghc-8.4.4
+        # - { build: stack, resolver: "--resolver lts-13"  }  redundant because lts-14 checks ghc-8.6 already
+        - { build: stack, resolver: "--resolver lts-14"  }   # ghc-8.6.5
+        - { build: stack, resolver: "--resolver nightly" }
+        - { build: stack, resolver: ""                   }
+        - { build: cabal, ghc: 8.0.2, cabal-install: "2.0"  }   # setup-haskell only supports cabal-install 2.0 and higher
+        - { build: cabal, ghc: 8.2.2, cabal-install: "2.0"  }
+        - { build: cabal, ghc: 8.4.4, cabal-install: "2.2"  }
+        - { build: cabal, ghc: 8.6.5, cabal-install: "2.4"  }
+        - { build: cabal, ghc: 8.8.1, cabal-install: "2.4"  }   # currently not working for >= 3.0
+        # use this to include any dependencies from OS package managers
+        include: []
+        # - os: macOS-latest
+        #   brew: anybrewdeps
+        # - os: ubuntu-latest
+        #   apt-get: happy libblas-dev liblapack-dev
 
-    runs-on: ubuntu-latest
+        exclude:
+        - os: macOS-latest
+          plan:
+            build: cabal
 
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - name: Install OS Packages
+      uses: mstksg/get-package@v1
       with:
-        ghc-version: '8.8.2'
-        cabal-version: '3.0'
+        apt-get: ${{ matrix.apt-get }}
+        brew: ${{ matrix.brew }}
+    - uses: actions/checkout@v1
+
+    - name: Setup stack
+      uses: mstksg/setup-stack@v1
+
+    - name: Setup cabal-install
+      uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.plan.ghc }}
+        cabal-version: ${{ matrix.plan.cabal-install }}
+      if: matrix.plan.build == 'cabal'
+
     - name: Install dependencies
       run: |
-        cabal update
-        cabal install --only-dependencies --enable-tests
+        set -ex
+        case "$BUILD" in
+          stack)
+            stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+            ;;
+          cabal)
+            cabal --version
+            cabal update
+            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+            cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+            ;;
+        esac
+        set +ex
+      env:
+        ARGS: ${{ matrix.plan.resolver }}
+        BUILD: ${{ matrix.plan.build }}
+
     - name: Build
       run: |
-        cabal configure --enable-tests
-        cabal build
-    - name: Run tests
-      run: cabal test
+        set -ex
+        case "$BUILD" in
+          stack)
+            stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+            ;;
+          cabal)
+            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+            cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+            ORIGDIR=$(pwd)
+            for dir in $PACKAGES
+            do
+              cd $dir
+              cabal check || [ "$CABALVER" == "1.16" ]
+              cabal sdist
+              PKGVER=$(cabal info . | awk '{print $2;exit}')
+              SRC_TGZ=$PKGVER.tar.gz
+              cd dist
+              tar zxfv "$SRC_TGZ"
+              cd "$PKGVER"
+              cabal configure --enable-tests --ghc-options -O0
+              cabal build
+              if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
+                cabal test
+              else
+                cabal test --show-details=streaming --log=/dev/stdout
+              fi
+              cd $ORIGDIR
+            done
+            ;;
+        esac
+        set +ex
+      env:
+        ARGS: ${{ matrix.plan.resolver }}
+        BUILD: ${{ matrix.plan.build }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -96,3 +96,5 @@ jobs:
       env:
         ARGS: ${{ matrix.plan.resolver }}
         BUILD: ${{ matrix.plan.build }}
+    - name: Test
+      run: stack test

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,19 +1,5 @@
-# Haskell stack project Github Actions template
-# https://gist.github.com/mstksg/11f753d891cee5980326a8ea8c865233
-#
-# To use, mainly change the list in 'plans' and modify 'include' for
-# any OS package manager deps.
-#
-# Currently not working for cabal-install >= 3
-#
-# Based on https://raw.githubusercontent.com/commercialhaskell/stack/stable/doc/travis-complex.yml
-#
-# TODO:
-# * cache (https://github.com/actions/cache)
-#     but this is too small. native cacheing will come soon
-#     https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974/highlight/true#M630
-#     so we can wait for then.
-# * support for cabal-install >= 3
+# Haskell stack project Github Action
+# Adapted from https://gist.github.com/mstksg/11f753d891cee5980326a8ea8c865233
 
 name: Haskell Stack Project CI
 
@@ -27,26 +13,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # use this to specify what resolvers and ghc to use
         plan:
-                #        - { build: stack, resolver: "--resolver lts-9"  }    # ghc-8.0.2
-                #        - { build: stack, resolver: "--resolver lts-11"  }   # ghc-8.2.2
-                #        - { build: stack, resolver: "--resolver lts-12"  }   # ghc-8.4.4
-                #        # - { build: stack, resolver: "--resolver lts-13"  }  redundant because lts-14 checks ghc-8.6 already
-        - { build: stack, resolver: "--resolver lts-14.4"  }  
-        # - { build: stack, resolver: "--resolver nightly" }
-        #        - { build: stack, resolver: ""                   }
-        #        - { build: cabal, ghc: 8.0.2, cabal-install: "2.0"  }   # setup-haskell only supports cabal-install 2.0 and higher
-        #        - { build: cabal, ghc: 8.2.2, cabal-install: "2.0"  }
-        #        - { build: cabal, ghc: 8.4.4, cabal-install: "2.2"  }
-        #        - { build: cabal, ghc: 8.6.5, cabal-install: "2.4"  }
-        #        - { build: cabal, ghc: 8.8.1, cabal-install: "2.4"  }   # currently not working for >= 3.0
-        # use this to include any dependencies from OS package managers
+          - { build: stack, resolver: "--resolver lts-14.4"  }
         include: []
-        # - os: macOS-latest
-        #   brew: anybrewdeps
-        # - os: ubuntu-latest
-        #   apt-get: happy libblas-dev liblapack-dev
 
         exclude:
         - os: macOS-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,21 +26,21 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
         # use this to specify what resolvers and ghc to use
         plan:
-        - { build: stack, resolver: "--resolver lts-9"  }    # ghc-8.0.2
-        - { build: stack, resolver: "--resolver lts-11"  }   # ghc-8.2.2
-        - { build: stack, resolver: "--resolver lts-12"  }   # ghc-8.4.4
-        # - { build: stack, resolver: "--resolver lts-13"  }  redundant because lts-14 checks ghc-8.6 already
-        - { build: stack, resolver: "--resolver lts-14"  }   # ghc-8.6.5
-        - { build: stack, resolver: "--resolver nightly" }
-        - { build: stack, resolver: ""                   }
-        - { build: cabal, ghc: 8.0.2, cabal-install: "2.0"  }   # setup-haskell only supports cabal-install 2.0 and higher
-        - { build: cabal, ghc: 8.2.2, cabal-install: "2.0"  }
-        - { build: cabal, ghc: 8.4.4, cabal-install: "2.2"  }
-        - { build: cabal, ghc: 8.6.5, cabal-install: "2.4"  }
-        - { build: cabal, ghc: 8.8.1, cabal-install: "2.4"  }   # currently not working for >= 3.0
+                #        - { build: stack, resolver: "--resolver lts-9"  }    # ghc-8.0.2
+                #        - { build: stack, resolver: "--resolver lts-11"  }   # ghc-8.2.2
+                #        - { build: stack, resolver: "--resolver lts-12"  }   # ghc-8.4.4
+                #        # - { build: stack, resolver: "--resolver lts-13"  }  redundant because lts-14 checks ghc-8.6 already
+        - { build: stack, resolver: "--resolver lts-14.4"  }  
+        # - { build: stack, resolver: "--resolver nightly" }
+        #        - { build: stack, resolver: ""                   }
+        #        - { build: cabal, ghc: 8.0.2, cabal-install: "2.0"  }   # setup-haskell only supports cabal-install 2.0 and higher
+        #        - { build: cabal, ghc: 8.2.2, cabal-install: "2.0"  }
+        #        - { build: cabal, ghc: 8.4.4, cabal-install: "2.2"  }
+        #        - { build: cabal, ghc: 8.6.5, cabal-install: "2.4"  }
+        #        - { build: cabal, ghc: 8.8.1, cabal-install: "2.4"  }   # currently not working for >= 3.0
         # use this to include any dependencies from OS package managers
         include: []
         # - os: macOS-latest

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ name: Haskell Stack Project CI
 on:
   push:
   schedule:
-  - cron: "0 0 * * 1"
+    - cron: '0 0 * * 1'
 
 jobs:
   build:
@@ -14,87 +14,87 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         plan:
-          - { build: stack, resolver: "--resolver lts-14.4"  }
+          - {build: stack, resolver: '--resolver lts-14.4'}
         include: []
 
         exclude:
-        - os: macOS-latest
-          plan:
-            build: cabal
+          - os: macOS-latest
+            plan:
+              build: cabal
 
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install OS Packages
-      uses: mstksg/get-package@v1
-      with:
-        apt-get: ${{ matrix.apt-get }}
-        brew: ${{ matrix.brew }}
-    - uses: actions/checkout@v1
+      - name: Install OS Packages
+        uses: mstksg/get-package@v1
+        with:
+          apt-get: ${{ matrix.apt-get }}
+          brew: ${{ matrix.brew }}
+      - uses: actions/checkout@v1
 
-    - name: Setup stack
-      uses: mstksg/setup-stack@v1
+      - name: Setup stack
+        uses: mstksg/setup-stack@v1
 
-    - name: Setup cabal-install
-      uses: actions/setup-haskell@v1
-      with:
-        ghc-version: ${{ matrix.plan.ghc }}
-        cabal-version: ${{ matrix.plan.cabal-install }}
-      if: matrix.plan.build == 'cabal'
+      - name: Setup cabal-install
+        uses: actions/setup-haskell@v1
+        with:
+          ghc-version: ${{ matrix.plan.ghc }}
+          cabal-version: ${{ matrix.plan.cabal-install }}
+        if: matrix.plan.build == 'cabal'
 
-    - name: Install dependencies
-      run: |
-        set -ex
-        case "$BUILD" in
-          stack)
-            stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
-            ;;
-          cabal)
-            cabal --version
-            cabal update
-            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-            cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-            ;;
-        esac
-        set +ex
-      env:
-        ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
+      - name: Install dependencies
+        run: |
+          set -ex
+          case "$BUILD" in
+            stack)
+              stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+              ;;
+            cabal)
+              cabal --version
+              cabal update
+              PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+              cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+              ;;
+          esac
+          set +ex
+        env:
+          ARGS: ${{ matrix.plan.resolver }}
+          BUILD: ${{ matrix.plan.build }}
 
-    - name: Build
-      run: |
-        set -ex
-        case "$BUILD" in
-          stack)
-            stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
-            ;;
-          cabal)
-            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-            cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-            ORIGDIR=$(pwd)
-            for dir in $PACKAGES
-            do
-              cd $dir
-              cabal check || [ "$CABALVER" == "1.16" ]
-              cabal sdist
-              PKGVER=$(cabal info . | awk '{print $2;exit}')
-              SRC_TGZ=$PKGVER.tar.gz
-              cd dist
-              tar zxfv "$SRC_TGZ"
-              cd "$PKGVER"
-              cabal configure --enable-tests --ghc-options -O0
-              cabal build
-              if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
-                cabal test
-              else
-                cabal test --show-details=streaming --log=/dev/stdout
-              fi
-              cd $ORIGDIR
-            done
-            ;;
-        esac
-        set +ex
-      env:
-        ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
-    - name: Test
-      run: stack test
+      - name: Build
+        run: |
+          set -ex
+          case "$BUILD" in
+            stack)
+              stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+              ;;
+            cabal)
+              PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+              cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+              ORIGDIR=$(pwd)
+              for dir in $PACKAGES
+              do
+                cd $dir
+                cabal check || [ "$CABALVER" == "1.16" ]
+                cabal sdist
+                PKGVER=$(cabal info . | awk '{print $2;exit}')
+                SRC_TGZ=$PKGVER.tar.gz
+                cd dist
+                tar zxfv "$SRC_TGZ"
+                cd "$PKGVER"
+                cabal configure --enable-tests --ghc-options -O0
+                cabal build
+                if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
+                  cabal test
+                else
+                  cabal test --show-details=streaming --log=/dev/stdout
+                fi
+                cd $ORIGDIR
+              done
+              ;;
+          esac
+          set +ex
+        env:
+          ARGS: ${{ matrix.plan.resolver }}
+          BUILD: ${{ matrix.plan.build }}
+      - name: Test
+        run: stack test


### PR DESCRIPTION
This currently only runs `stack test` on lts-14.4 stack resolver on Ubuntu but could be extended to do more. It also schedules it to run weekly. 

One thing I am also working on is grabbing random openscad files from Github and running the parser on those. 