### PR TITLE
Pretty-printer and roundtrip tests

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -136,6 +136,19 @@ module myModule() {
     [ testFormat 80 [s|
 myVar = true;|]
     ]
+  , testGroup "FuncDef"
+    [ testFormat 80 [s|
+function myFunc() = true;|]
+    , testFormat 10 [s|
+function myFunc()
+  = true;|]
+    , testFormat 80 [s|
+function myFunc(arg1, arg2) = true;|]
+    , testFormat 10 [s|
+function myFunc( arg1
+               , arg2 )
+  = true;|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -20,7 +20,7 @@ import Test.Tasty.Silver
 main :: IO ()
 main = do
     testTree <- getTests
-    defaultMain $ testGroup "tests" [testTree, roundtripTests, exactprintTests, parseTests]
+    defaultMain $ testGroup "tests" [testTree, roundtripTests, exactprintTests, parseTests, prettyTests]
 
 getTests :: IO TestTree
 getTests = do
@@ -55,6 +55,16 @@ dumpScad file = do
     case result of
       Left err -> fail err
       Right a  -> return $ ppShow a
+
+prettyTests :: TestTree
+prettyTests = testGroup "pretty tests"
+  [ testPretty (EString s) ("\"" <> s' <> "\"") 
+  | (s', s) <- [("\\\"","\""), ("\\\\","\\"), ("\\t","\t"), ("\\n","\n"), ("\\r", "\r")]
+  ]
+  where
+    testPretty :: (HasCallStack, PP.Pretty a) => a -> String -> TestTree
+    testPretty e s = testCase s $
+      PP.renderString (PP.layoutPretty PP.defaultLayoutOptions $ PP.pretty e) @?= s
 
 exactprintTests :: TestTree
 exactprintTests = testGroup "exactprint tests"

--- a/Test.hs
+++ b/Test.hs
@@ -223,7 +223,11 @@ myVar
   = myFunc( arg1
           , arg2 );|]
     , testFormat 80 [s|
-myVar = ! myVar2;|] -- FIXME
+myVar = !myVar2;|]
+    , testFormat 80 [s|
+myVar = -myVar2;|]
+    , testFormat 80 [s|
+myVar = -(myVar2);|]
     , testFormat 80 [s|
 myVar = a + b;|]
     , testFormat 15 [s|
@@ -268,6 +272,13 @@ parseTests :: TestTree
 parseTests = testGroup "parse tests"
   [ testParse expression "a[b]" $ EIndex (EVar (Ident "a")) (EVar (Ident "b"))
   , testParse expression "a[b][c]" $ EIndex (EIndex (EVar (Ident "a")) (EVar (Ident "b"))) (EVar (Ident "c"))
+  , testParse expression "-1" $ ENum (negate 1)
+  , testParse expression "-(1)" $ ENegate (EParen (ENum 1))
+  , testParse expression "+1" $ ENum 1
+  , testParse expression "+(1)" $ EParen (ENum 1)
+  -- Not supported atm
+  -- , testParse expression "--1" $ ENegate (ENum (negate 1))
+  -- , testParse expression "+-1" $ ENum (negate 1)
   ]
   where
     testParse :: (Eq a, Show a) => Parser a -> String -> a -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -20,7 +20,7 @@ import Test.Tasty.Silver
 main :: IO ()
 main = do
     testTree <- getTests
-    defaultMain $ testGroup "tests" [testTree, roundTripTests, prettyTests, parseTests]
+    defaultMain $ testGroup "tests" [testTree, roundtripTests, exactprintTests, parseTests]
 
 getTests :: IO TestTree
 getTests = do
@@ -31,8 +31,8 @@ getTests = do
         , let base = takeBaseName file
         ]
 
-roundTripTests :: TestTree
-roundTripTests = testGroup "roundtrip tests"
+roundtripTests :: TestTree
+roundtripTests = testGroup "roundtrip tests"
   [ roundtrip "ident" ident
   , roundtrip "expression" expression
   , roundtrip "object" object
@@ -56,32 +56,32 @@ dumpScad file = do
       Left err -> fail err
       Right a  -> return $ ppShow a
 
-prettyTests :: TestTree
-prettyTests = testGroup "pretty tests"
+exactprintTests :: TestTree
+exactprintTests = testGroup "exactprint tests"
   [ testGroup "Module"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 myModule();|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myModule();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule(arg1);|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule(arg1, arg2);|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule(arg1 = 1.0, arg2);|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule() myModule2();|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 myModule( arg1
         , arg2 );|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 myModule()
   myModule2();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule() { foo(); }|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myModule() { foo(); bar(); }|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 myModule() {
   foo();
   bar();
@@ -89,184 +89,184 @@ myModule() {
 }|]
     ]
   , testGroup "ForLoop"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 for(myVar = 1.0) myModule();|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 for(myVar = 1.0)
   myModule();|]
     ]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 for(myVar = true) { foo(); bar(); }|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 for(myVar = true) {
   foo();
   bar();
   baz();
 }|]
   , testGroup "Objects"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 { myModule1(); myModule2(); }|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 {
   myModule1();
   myModule2();
 }|]
     ]
   , testGroup "If"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 if (true) myModule();|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 if (true)
   myModule();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 if (true) { myModule(); myModule(); }|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 if (true) {
   myModule();
   myModule();
 }|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 if (true) if (true) foo();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 if (true) { if (true) foo(); else bar(); }|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 if (true) { if (true) foo(); } else bar();|]
     ]
   , testGroup "*Mod"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 %myModule();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 #myModule();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 !myModule();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 *myModule();|]
     ]
   , testGroup "ModuleDef"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 module myModule() {}|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 module myModule() {}|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 module myModule(arg1, arg2, arg3 = true) {}|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 module myModule( arg1
                , arg2
                , arg3 = true ) {}|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 module myModule() { myModule2(); myModule2(); }|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 module myModule() {
   myModule2();
   myModule2();
 }|]
     ]
   , testGroup "VarDef"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 myVar = true;|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myVar
   = true;|]
     ]
   , testGroup "FuncDef"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 function myFunc() = true;|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 function myFunc()
   = true;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 function myFunc(arg1, arg2) = true;|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 function myFunc( arg1
                , arg2 )
   = true;|]
     ]
   , testGroup "Expr"
-    [ testFormat 80 [s|
+    [ testExactprint 80 [s|
 myVar = myVar2;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = myVar2[foo];|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = 1.0;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = [true, false];|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 myVariables
   = [aaa, b];|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myVar
   = [ true
     , false ];|]
     ]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = [true:false];|]
-    , testFormat 25 [s|
+    , testExactprint 25 [s|
 myVariables
   = [true:false];|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 myVar
   = [ true
     : false ];|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = "myString";|]
     , testGroup "string escapings"
-      [ testFormat 80 (mconcat ["myVar = \"" <> s <> "\";"])
+      [ testExactprint 80 (mconcat ["myVar = \"" <> s <> "\";"])
       | s <- ["\\\"", "\\\\", "\\t", "\\n", "\\r"]
       ]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = true;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = false;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = myFunc();|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = myFunc(arg1, arg2);|]
-    , testFormat 25 [s|
+    , testExactprint 25 [s|
 myVar
   = myFunc(arg1, arg2);|]
-    , testFormat 20 [s|
+    , testExactprint 20 [s|
 myVar
   = myFunc( arg1
           , arg2 );|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = !myVar2;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = -myVar2;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = -(myVar2);|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = a + b;|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 myVariable
   = aaaaa + b;|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myVarable
   = aaaaa
     + b;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = a ? b : c;|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 myVar
   = a ? b : c;|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myVar
   = aaaa
     ? b
     : c;|]
-    , testFormat 80 [s|
+    , testExactprint 80 [s|
 myVar = (a + b);|]
-    , testFormat 15 [s|
+    , testExactprint 15 [s|
 myVariable
   = (a + b);|]
-    , testFormat 10 [s|
+    , testExactprint 10 [s|
 myVar
   = ( aaaaa
       + b
       + c );|]
   ]
  where
-   testFormat :: HasCallStack => Int -> String -> TestTree
-   testFormat w src = testCase src $ case parse (BS8.pack src) of 
+   testExactprint :: HasCallStack => Int -> String -> TestTree
+   testExactprint w src = testCase src $ case parse (BS8.pack src) of 
      Left e -> assertFailure $ "Parse failure: " <> e
      Right [tl] ->
        let opts = PP.LayoutOptions $ PP.AvailablePerLine w 1

--- a/Test.hs
+++ b/Test.hs
@@ -85,6 +85,13 @@ for(myVar = 1.0) myModule();|]
 for(myVar = 1.0)
   myModule();|]
     ]
+  , testGroup "Objects"
+    [ testFormat 80 [s|
+{
+  myModule1();
+  myModule2();
+}|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -149,6 +149,8 @@ module myModule( arg1
                , arg2
                , arg3 = true ) {}|]
     , testFormat 80 [s|
+module myModule() { myModule2(); myModule2(); }|]
+    , testFormat 20 [s|
 module myModule() {
   myModule2();
   myModule2();

--- a/Test.hs
+++ b/Test.hs
@@ -77,6 +77,16 @@ myModule( arg1
     , testFormat 20 [s|
 myModule()
   myModule2();|]
+    , testFormat 80 [s|
+myModule() { foo(); }|]
+    , testFormat 80 [s|
+myModule() { foo(); bar(); }|]
+    , testFormat 15 [s|
+myModule() {
+  foo();
+  bar();
+  baz();
+}|]
     ]
   , testGroup "ForLoop"
     [ testFormat 80 [s|
@@ -85,8 +95,18 @@ for(myVar = 1.0) myModule();|]
 for(myVar = 1.0)
   myModule();|]
     ]
+    , testFormat 80 [s|
+for(myVar = true) { foo(); bar(); }|]
+    , testFormat 15 [s|
+for(myVar = true) {
+  foo();
+  bar();
+  baz();
+}|]
   , testGroup "Objects"
     [ testFormat 80 [s|
+{ myModule1(); myModule2(); }|]
+    , testFormat 20 [s|
 {
   myModule1();
   myModule2();
@@ -100,6 +120,8 @@ if (true) myModule();|]
 if (true)
   myModule();|]
     , testFormat 80 [s|
+if (true) { myModule(); myModule(); }|]
+    , testFormat 20 [s|
 if (true) {
   myModule();
   myModule();

--- a/Test.hs
+++ b/Test.hs
@@ -132,6 +132,10 @@ module myModule() {
   myModule2();
 }|]
     ]
+  , testGroup "VarDef"
+    [ testFormat 80 [s|
+myVar = true;|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -32,6 +32,7 @@ roundTripTests = testGroup "roundtrip tests"
   [ roundtrip "ident" ident
   , roundtrip "expression" expression
   , roundtrip "object" object
+  , roundtrip "topLevel" topLevel
   ]
  where
    parse :: Parser a -> String -> Result a 

--- a/Test.hs
+++ b/Test.hs
@@ -135,6 +135,9 @@ module myModule() {
   , testGroup "VarDef"
     [ testFormat 80 [s|
 myVar = true;|]
+    , testFormat 10 [s|
+myVar
+  = true;|]
     ]
   , testGroup "FuncDef"
     [ testFormat 80 [s|
@@ -159,8 +162,8 @@ myVar = 1.0;|]
     , testFormat 80 [s|
 myVar = [true, false];|]
     , testFormat 20 [s|
-myVar = [ true
-        , false ];|]
+myVariables
+  = [aaa, b];|]
     , testFormat 10 [s|
 myVar
   = [ true
@@ -168,9 +171,13 @@ myVar
     ]
     , testFormat 80 [s|
 myVar = [true:false];|]
-    , testFormat 20 [s|
-myVar = [ true
-        : false ];|]
+    , testFormat 25 [s|
+myVariables
+  = [true:false];|]
+    , testFormat 15 [s|
+myVar
+  = [ true
+    : false ];|]
     , testFormat 80 [s|
 myVar = "myString";|]
     , testFormat 80 [s|
@@ -184,22 +191,44 @@ myVar = false;|]
 myVar = myFunc();|]
     , testFormat 80 [s|
 myVar = myFunc(arg1, arg2);|]
+    , testFormat 25 [s|
+myVar
+  = myFunc(arg1, arg2);|]
     , testFormat 20 [s|
-myVar = myFunc( arg1
-              , arg2 );|]
+myVar
+  = myFunc( arg1
+          , arg2 );|]
     , testFormat 80 [s|
 myVar = ! myVar2;|] -- FIXME
     , testFormat 80 [s|
 myVar = a + b;|]
     , testFormat 15 [s|
-myVar = aaaaa
-        + b;|]
+myVariable
+  = aaaaa + b;|]
+    , testFormat 10 [s|
+myVarable
+  = aaaaa
+    + b;|]
     , testFormat 80 [s|
 myVar = a ? b : c;|]
     , testFormat 15 [s|
-myVar = aaaaa
-        ? b
-        : c;|]
+myVar
+  = a ? b : c;|]
+    , testFormat 10 [s|
+myVar
+  = aaaa
+    ? b
+    : c;|]
+    , testFormat 80 [s|
+myVar = (a + b);|]
+    , testFormat 15 [s|
+myVariable
+  = (a + b);|]
+    , testFormat 10 [s|
+myVar
+  = ( aaaaa
+      + b
+      + c );|]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -30,9 +30,12 @@ getTests = do
 roundTripTests :: TestTree
 roundTripTests = testGroup "roundtrip tests"
   [ roundtrip "ident" ident
+  , roundtrip "expression" expression
   ]
  where
+   parse :: Parser a -> String -> Result a 
    parse p = parseString p mempty
+   render :: PP.Pretty a => a -> String
    render = PP.renderString . PP.layoutCompact . PP.pretty
    roundtrip name p = QC.testProperty name $ \e -> parse p (render e) `isSuccess` e
 

--- a/Test.hs
+++ b/Test.hs
@@ -113,8 +113,7 @@ for(myVar = true) {
 }|]
     ]
   , testGroup "If"
-    [
-      testFormat 80 [s|
+    [ testFormat 80 [s|
 if (true) myModule();|]
     , testFormat 20 [s|
 if (true)
@@ -126,6 +125,12 @@ if (true) {
   myModule();
   myModule();
 }|]
+    , testFormat 80 [s|
+if (true) if (true) foo();|]
+    , testFormat 80 [s|
+if (true) { if (true) foo(); else bar(); }|]
+    , testFormat 80 [s|
+if (true) { if (true) foo(); } else bar();|]
     ]
   , testGroup "*Mod"
     [ testFormat 80 [s|

--- a/Test.hs
+++ b/Test.hs
@@ -149,6 +149,57 @@ function myFunc( arg1
                , arg2 )
   = true;|]
     ]
+  , testGroup "Expr"
+    [ testFormat 80 [s|
+myVar = myVar2;|]
+    , testFormat 80 [s|
+myVar = myVar2[foo];|]
+    , testFormat 80 [s|
+myVar = 1.0;|]
+    , testFormat 80 [s|
+myVar = [true, false];|]
+    , testFormat 20 [s|
+myVar = [ true
+        , false ];|]
+    , testFormat 10 [s|
+myVar
+  = [ true
+    , false ];|]
+    ]
+    , testFormat 80 [s|
+myVar = [true:false];|]
+    , testFormat 20 [s|
+myVar = [ true
+        : false ];|]
+    , testFormat 80 [s|
+myVar = "myString";|]
+    , testFormat 80 [s|
+myVar = "myString\"";|]
+    -- TODO: string escapings
+    , testFormat 80 [s|
+myVar = true;|]
+    , testFormat 80 [s|
+myVar = false;|]
+    , testFormat 80 [s|
+myVar = myFunc();|]
+    , testFormat 80 [s|
+myVar = myFunc(arg1, arg2);|]
+    , testFormat 20 [s|
+myVar = myFunc( arg1
+              , arg2 );|]
+    , testFormat 80 [s|
+myVar = ! myVar2;|] -- FIXME
+    , testFormat 80 [s|
+myVar = a + b;|]
+    , testFormat 15 [s|
+myVar = aaaaa
+        + b;|]
+    , testFormat 80 [s|
+myVar = a ? b : c;|]
+    , testFormat 15 [s|
+myVar = aaaaa
+        ? b
+        : c;|]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -105,6 +105,16 @@ if (true) {
   myModule();
 }|]
     ]
+  , testGroup "*Mod"
+    [ testFormat 80 [s|
+%myModule();|]
+    , testFormat 80 [s|
+#myModule();|]
+    , testFormat 80 [s|
+!myModule();|]
+    , testFormat 80 [s|
+*myModule();|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -78,6 +78,13 @@ myModule( arg1
 myModule()
   myModule2();|]
     ]
+  , testGroup "ForLoop"
+    [ testFormat 80 [s|
+for(myVar = 1.0) myModule();|]
+    , testFormat 20 [s|
+for(myVar = 1.0)
+  myModule();|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -209,9 +209,10 @@ myVar
     : false ];|]
     , testFormat 80 [s|
 myVar = "myString";|]
-    , testFormat 80 [s|
-myVar = "myString\"";|]
-    -- TODO: string escapings
+    , testGroup "string escapings"
+      [ testFormat 80 (mconcat ["myVar = \"" <> s <> "\";"])
+      | s <- ["\\\"", "\\\\", "\\t", "\\n", "\\r"]
+      ]
     , testFormat 80 [s|
 myVar = true;|]
     , testFormat 80 [s|
@@ -274,7 +275,7 @@ myVar
       "Parse failure: expected single TopLevel but got:\n" <> show (PP.vsep $ PP.pretty <$> tls)
 
 parseTests :: TestTree
-parseTests = testGroup "parse tests"
+parseTests = testGroup "parse tests" $ 
   [ testParse expression "a[b]" $ EIndex (EVar (Ident "a")) (EVar (Ident "b"))
   , testParse expression "a[b][c]" $ EIndex (EIndex (EVar (Ident "a")) (EVar (Ident "b"))) (EVar (Ident "c"))
   , testParse expression "-1" $ ENum (negate 1)
@@ -284,6 +285,9 @@ parseTests = testGroup "parse tests"
   -- Not supported atm
   -- , testParse expression "--1" $ ENegate (ENum (negate 1))
   -- , testParse expression "+-1" $ ENum (negate 1)
+  ] <>
+  [ testParse expression ("\"" <> s <> "\"") (EString s')
+  | (s, s') <- [("\\\"","\""), ("\\\\","\\"), ("\\t","\t"), ("\\n","\n"), ("\\r", "\r")]
   ]
   where
     testParse :: (Eq a, Show a) => Parser a -> String -> a -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -292,9 +292,11 @@ parseTests = testGroup "parse tests" $
   , testParse expression "-(1)" $ ENegate (EParen (ENum 1))
   , testParse expression "+1" $ ENum 1
   , testParse expression "+(1)" $ EParen (ENum 1)
+  , testParse expression "-1 + 2" $ EPlus (ENum (negate 1)) (ENum 2)
   -- Not supported atm
   -- , testParse expression "--1" $ ENegate (ENum (negate 1))
   -- , testParse expression "+-1" $ ENum (negate 1)
+  -- , testParse expression "!-1" $ ENot (ENum (negate 1))
   ] <>
   [ testParse expression ("\"" <> s <> "\"") (EString s')
   | (s, s') <- [("\\\"","\""), ("\\\\","\\"), ("\\t","\t"), ("\\n","\n"), ("\\r", "\r")]

--- a/Test.hs
+++ b/Test.hs
@@ -35,9 +35,9 @@ roundTripTests = testGroup "roundtrip tests"
   , roundtrip "topLevel" topLevel
   ]
  where
-   parse :: Parser a -> String -> Result a 
+   parse :: HasCallStack => Parser a -> String -> Result a 
    parse p = parseString p mempty
-   render :: PP.Pretty a => a -> String
+   render :: (HasCallStack, PP.Pretty a) => a -> String
    render = PP.renderString . PP.layoutCompact . PP.pretty
    roundtrip name p = QC.testProperty name $ \e -> parse p (render e) `isSuccess` e
 

--- a/Test.hs
+++ b/Test.hs
@@ -92,6 +92,19 @@ for(myVar = 1.0)
   myModule2();
 }|]
     ]
+  , testGroup "If"
+    [
+      testFormat 80 [s|
+if (true) myModule();|]
+    , testFormat 20 [s|
+if (true)
+  myModule();|]
+    , testFormat 80 [s|
+if (true) {
+  myModule();
+  myModule();
+}|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -115,6 +115,23 @@ if (true) {
     , testFormat 80 [s|
 *myModule();|]
     ]
+  , testGroup "ModuleDef"
+    [ testFormat 80 [s|
+module myModule() {}|]
+    , testFormat 10 [s|
+module myModule() {}|]
+    , testFormat 80 [s|
+module myModule(arg1, arg2, arg3 = true) {}|]
+    , testFormat 10 [s|
+module myModule( arg1
+               , arg2
+               , arg3 = true ) {}|]
+    , testFormat 80 [s|
+module myModule() {
+  myModule2();
+  myModule2();
+}|]
+    ]
   ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree

--- a/Test.hs
+++ b/Test.hs
@@ -31,6 +31,7 @@ roundTripTests :: TestTree
 roundTripTests = testGroup "roundtrip tests"
   [ roundtrip "ident" ident
   , roundtrip "expression" expression
+  , roundtrip "object" object
   ]
  where
    parse :: Parser a -> String -> Result a 

--- a/Test.hs
+++ b/Test.hs
@@ -58,7 +58,27 @@ dumpScad file = do
 
 prettyTests :: TestTree
 prettyTests = testGroup "pretty tests"
-  []
+  [ testGroup "Module"
+    [ testFormat 80 [s|
+myModule();|]
+    , testFormat 10 [s|
+myModule();|]
+    , testFormat 80 [s|
+myModule(arg1);|]
+    , testFormat 80 [s|
+myModule(arg1, arg2);|]
+    , testFormat 80 [s|
+myModule(arg1 = 1.0, arg2);|]
+    , testFormat 80 [s|
+myModule() myModule2();|]
+    , testFormat 20 [s|
+myModule( arg1
+        , arg2 );|]
+    , testFormat 20 [s|
+myModule()
+  myModule2();|]
+    ]
+  ]
  where
    testFormat :: HasCallStack => Int -> String -> TestTree
    testFormat w src = testCase src $ case parse (BS8.pack src) of 

--- a/language-openscad.cabal
+++ b/language-openscad.cabal
@@ -25,7 +25,9 @@ library
                        charset >= 0.3 && < 0.4,
                        parsers >= 0.12 && <0.13,
                        scientific >= 0.3,
-                       bytestring >=0.10 && <0.11
+                       bytestring >=0.10 && <0.11,
+                       prettyprinter >= 1.2,
+                       QuickCheck >= 2.13 && <2.14
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -37,9 +39,13 @@ test-suite test-parse-openscad
                        bytestring,
                        filepath,
                        pretty-show,
+                       prettyprinter,
+                       QuickCheck,
                        text,
+                       trifecta,
                        tasty,
                        tasty-silver,
+                       tasty-quickcheck,
                        language-openscad
   default-language:    Haskell2010
 

--- a/language-openscad.cabal
+++ b/language-openscad.cabal
@@ -41,9 +41,11 @@ test-suite test-parse-openscad
                        pretty-show,
                        prettyprinter,
                        QuickCheck,
+                       string-qq,
                        text,
                        trifecta,
                        tasty,
+                       tasty-hunit,
                        tasty-silver,
                        tasty-quickcheck,
                        language-openscad

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -273,8 +273,7 @@ instance QC.Arbitrary Expr where
               , do
                   l <- QC.choose (0,n)
                   EFunc <$> QC.arbitrary <*> QC.vectorOf l (QC.resize (n `div` l) QC.arbitrary)
-              -- FIXME: gives errors
-              -- , EIndex <$> QC.resize (n`div`2) QC.arbitrary <*> QC.resize (n`div`2) QC.arbitrary
+              , EIndex <$> QC.resize (n`div`2) (QC.oneof $ simpleTerms <> recursiveTerms) <*> QC.resize (n`div`2) QC.arbitrary
               ]
           ops
             = [ ETernary <$> QC.resize (n`div`3) (QC.oneof simpleTerms) <*> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary | p == 0
@@ -449,9 +448,9 @@ term = do
     , ENum <$> double'
     , EParen <$> parens expression
     ]
-  idx <- optional $ brackets expression <?> "index expression"
+  idxs <- many $ brackets expression <?> "index expression"
   spaces
-  return $ maybe e (e `EIndex`) idx
+  return $ foldl' EIndex e idxs
   where
     funcRef = do
       name <- ident

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -160,8 +160,8 @@ instance PP.Pretty Object where
                mBody 
     ForLoop i e o ->
       "for"
-      <> PP.parens (PP.pretty i <> "=" <> PP.pretty e)
-      <> PP.pretty o
+      <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
+      <> PP.nest 2 (PP.softline <> PP.pretty o)
     Objects os -> 
       PP.braces . PP.vsep $ PP.pretty <$> os
     If c t me ->

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -170,8 +170,14 @@ instance PP.Pretty Object where
     If c t me ->
       "if"
       <+> PP.parens (PP.pretty c)
-      <+> PP.pretty t
-      <+> maybe mempty (("else" <+>) . PP.pretty) me
+      <> (case t of
+            Objects _ -> PP.space <> PP.pretty t
+            _ -> PP.nest 2 (PP.softline <> PP.pretty t)
+            )
+      <> maybe
+           mempty
+           (\e -> PP.softline <> "else" <> PP.softline <> PP.pretty e)
+           me
     BackgroundMod o ->
       "%" <> PP.pretty o
     DebugMod o ->

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -28,7 +28,7 @@ import qualified Data.CharSet.Unicode as CS
 import Data.Monoid ((<>))
 import qualified Data.Text.Prettyprint.Doc as PP
 import Data.Text.Prettyprint.Doc ((<+>))
-import GHC.Generics (Generic(..))
+import GHC.Generics (Generic(..), Generic1(..))
 import qualified Test.QuickCheck as QC
 import Text.Trifecta hiding (ident)
 import Text.Parser.Expression
@@ -177,7 +177,10 @@ instance PP.Pretty Expr where
 -- | @Range start end step@ denotes a list starting at @start@ and
 -- stopping at @end@ with increments of @step@.
 data Range a = Range a a (Maybe a)
-             deriving (Show)
+             deriving (Show, Eq, Generic1)
+
+instance QC.Arbitrary a => QC.Arbitrary (Range a) where
+  arbitrary = Range <$> QC.arbitrary <*> QC.arbitrary <*> QC.arbitrary
 
 instance PP.Pretty a => PP.Pretty (Range a) where
   pretty (Range start stop step) =

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -159,13 +159,13 @@ instance PP.Pretty Object where
       <> case mBody of
       Nothing -> PP.semi
       Just os@(Objects _) -> PP.space <> PP.pretty os
-      Just o -> PP.nest 2 $ PP.softline <> PP.pretty o
+      Just o -> PP.nest 2 $ PP.line <> PP.pretty o
     ForLoop i e o ->
       "for"
       <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
       <> case o of
           Objects _ -> PP.space <> PP.pretty o
-          _ -> PP.nest 2 $ PP.softline <> PP.pretty o
+          _ -> PP.nest 2 $ PP.line <> PP.pretty o
     Objects os -> 
       PP.enclose PP.lbrace (PP.line <> PP.rbrace)
       . PP.nest 2
@@ -175,11 +175,11 @@ instance PP.Pretty Object where
       <+> PP.parens (PP.pretty c)
       <> (case t of
             Objects _ -> PP.space <> PP.pretty t
-            _ -> PP.nest 2 (PP.softline <> PP.pretty t)
+            _ -> PP.nest 2 (PP.line <> PP.pretty t)
             )
       <> maybe
            mempty
-           (\e -> PP.softline <> "else" <> PP.softline <> PP.pretty e)
+           (\e -> PP.line <> "else" <> PP.line <> PP.pretty e)
            me
     BackgroundMod o ->
       "%" <> PP.pretty o
@@ -200,8 +200,8 @@ instance PP.Pretty Object where
       <> (case moduleBody of
             [] -> PP.space <> PP.lbrace <> PP.rbrace
             _ -> PP.space
-              <> PP.enclose (PP.lbrace <> PP.hardline)
-                            (PP.hardline <> PP.rbrace)
+              <> PP.enclose (PP.lbrace <> PP.line)
+                            (PP.line <> PP.rbrace)
                    (PP.indent 2 . PP.vcat $ PP.pretty <$> moduleBody)
          )
     VarDef { varName, varValue } -> 
@@ -218,7 +218,7 @@ instance PP.Pretty Object where
            else PP.align . PP.tupled $ PP.pretty <$> funcArgs
          )
       <> PP.nest 2
-          (PP.softline
+          (PP.line
           <> PP.equals
           <+> PP.pretty funcBody
           <> PP.semi)
@@ -338,7 +338,7 @@ instance PP.Pretty Expr where
     EParen e1 -> PP.group . PP.align . PP.enclose (PP.flatAlt "( " "(") (PP.flatAlt " )" ")") $ PP.pretty e1
    where
     prefix op e1 = op <+> PP.pretty e1 -- FIXME: use `<>` instead, fails atm
-    binary op e1 e2 = PP.align $ PP.pretty e1 <> PP.softline <> op <+> PP.pretty e2
+    binary op e1 e2 = PP.align $ PP.pretty e1 <> PP.line <> op <+> PP.pretty e2
     ternary op1 op2 e1 e2 e3 =
       let f s = PP.pretty e1 <> s <> op1 <+> PP.pretty e2 <> s <> op2 <+> PP.pretty e3
       in PP.group $ PP.align (f PP.line) `PP.flatAlt` f PP.space

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -128,9 +128,10 @@ instance QC.Arbitrary Object where
         l <- QC.choose (0, n)
         let n' = n `div` max l 1
         Objects <$> QC.vectorOf l (rec n')
-    -- FIXME: nested if-else gives issues
-    -- , let n' = n `div` 3
-    --   in If <$> QC.resize n' QC.arbitrary <*> rec n' <*> QC.resize n' QC.arbitrary
+    , let n' = n `div` 3
+      -- TODO: Generate `if-then` without `else`, such that there are no nested
+      -- `if-then`s. That's an OpenSCAD quirk
+      in If <$> QC.resize n' QC.arbitrary <*> rec n' <*> (Just <$> QC.resize n' QC.arbitrary)
     , BackgroundMod <$> rec (n-1)
     , DebugMod <$> rec (n-1)
     , RootMod <$> rec (n-1)

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -152,8 +152,12 @@ instance PP.Pretty Object where
   pretty v = case v of
     Module i args mBody ->
       PP.pretty i
-      <> PP.tupled (PP.pretty <$> args)
-      <> maybe PP.semi PP.pretty mBody 
+      <> (if null args
+           then PP.lparen <> PP.rparen
+           else PP.align (PP.tupled (PP.pretty <$> args)))
+      <> maybe PP.semi
+               (PP.nest 2 . mappend PP.softline . PP.pretty)
+               mBody 
     ForLoop i e o ->
       "for"
       <> PP.parens (PP.pretty i <> "=" <> PP.pretty e)

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -209,11 +209,16 @@ instance PP.Pretty Object where
       <> PP.semi
     FuncDef { funcName, funcArgs, funcBody } -> 
       "function"
-      <> PP.pretty funcName
-      <> PP.tupled (PP.pretty <$> funcArgs)
-      <> PP.equals
-      <> PP.pretty funcBody
-      <> PP.semi
+      <+> PP.pretty funcName
+      <> (if null funcArgs
+           then PP.lparen <> PP.rparen
+           else PP.align . PP.tupled $ PP.pretty <$> funcArgs
+         )
+      <> PP.nest 2
+          (PP.softline
+          <> PP.equals
+          <+> PP.pretty funcBody
+          <> PP.semi)
 
 -- | An OpenSCAD expression
 data Expr

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -156,18 +156,20 @@ instance PP.Pretty Object where
       <> (if null args
            then PP.lparen <> PP.rparen
            else PP.align (PP.tupled (PP.pretty <$> args)))
-      <> maybe PP.semi
-               (PP.nest 2 . mappend PP.softline . PP.pretty)
-               mBody 
+      <> case mBody of
+      Nothing -> PP.semi
+      Just os@(Objects _) -> PP.space <> PP.pretty os
+      Just o -> PP.nest 2 $ PP.softline <> PP.pretty o
     ForLoop i e o ->
       "for"
       <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
-      <> PP.nest 2 (PP.softline <> PP.pretty o)
+      <> case o of
+          Objects _ -> PP.space <> PP.pretty o
+          _ -> PP.nest 2 $ PP.softline <> PP.pretty o
     Objects os -> 
-      PP.enclose (PP.lbrace <> PP.hardline) (PP.hardline <> PP.rbrace) 
-        . PP.indent 2
-        . PP.vcat
-        $ PP.pretty <$> os
+      PP.enclose PP.lbrace (PP.line <> PP.rbrace)
+      . PP.nest 2
+      $ PP.line <> PP.vsep (PP.pretty <$> os)
     If c t me ->
       "if"
       <+> PP.parens (PP.pretty c)

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -150,7 +150,7 @@ instance QC.Arbitrary Object where
   shrink = QC.genericShrink
 
 instance PP.Pretty Object where
-  pretty v = case v of
+  pretty v = PP.group $ case v of
     Module i args mBody ->
       PP.pretty i
       <> (if null args
@@ -205,10 +205,9 @@ instance PP.Pretty Object where
     VarDef { varName, varValue } -> 
       PP.pretty varName
       <> PP.nest 2
-          (PP.softline
+          ( PP.line
           <> PP.equals
-          <+> PP.pretty varValue
-          <> PP.semi)
+          <+> PP.group (PP.pretty varValue <> PP.semi))
     FuncDef { funcName, funcArgs, funcBody } -> 
       "function"
       <+> PP.pretty funcName
@@ -334,7 +333,7 @@ instance PP.Pretty Expr where
     EOr e1 e2 -> binary "||" e1 e2
     EAnd e1 e2 -> binary "&&" e1 e2
     ETernary e1 e2 e3 -> ternary "?" ":" e1 e2 e3
-    EParen e1 -> PP.parens $ PP.pretty e1
+    EParen e1 -> PP.group . PP.align . PP.enclose (PP.flatAlt "( " "(") (PP.flatAlt " )" ")") $ PP.pretty e1
    where
     prefix op e1 = op <+> PP.pretty e1 -- FIXME: use `<>` instead, fails atm
     binary op e1 e2 = PP.align $ PP.pretty e1 <> PP.softline <> op <+> PP.pretty e2

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -272,8 +272,10 @@ instance QC.Arbitrary Expr where
             , do
                 l <- QC.choose (0,n)
                 EFunc <$> QC.arbitrary <*> QC.vectorOf l (QC.resize (n `div` l) QC.arbitrary)
-            , EIndex <$> QC.resize (n`div`2) QC.arbitrary <*> QC.resize (n`div`2) QC.arbitrary
-            , ETernary <$> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary
+            -- FIXME: gives errors
+            -- , EIndex <$> QC.resize (n`div`2) QC.arbitrary <*> QC.resize (n`div`2) QC.arbitrary
+            -- FIXME: #1 must be a term, not an expression
+            -- , ETernary <$> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary
             , EParen <$> QC.resize (n - 1) QC.arbitrary
             ] ++ catMaybes
             [ genOp p' op

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -271,6 +271,9 @@ instance QC.Arbitrary Expr where
             , do
                 l <- QC.choose (0,n)
                 EFunc <$> QC.arbitrary <*> QC.vectorOf l (QC.resize (n `div` l) QC.arbitrary)
+            , EIndex <$> QC.resize (n`div`2) QC.arbitrary <*> QC.resize (n`div`2) QC.arbitrary
+            , ETernary <$> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary <*> QC.resize (n`div`3) QC.arbitrary
+            , EParen <$> QC.resize (n - 1) QC.arbitrary
             ] ++ catMaybes
             [ genOp p' op
             | (p',ops) <- zip (reverse [1 .. length opTable']) opTable'

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -130,6 +130,11 @@ data Expr
 data Range a = Range a a (Maybe a)
              deriving (Show)
 
+instance PP.Pretty a => PP.Pretty (Range a) where
+  pretty (Range start stop step) =
+    PP.encloseSep PP.lbracket PP.rbracket PP.colon
+    . fmap PP.pretty
+    $ [start, stop] <> maybe [] pure step
 
 sepByTill :: Parser delim -> Parser end -> Parser a -> Parser [a]
 sepByTill delim end parser = (end *> return []) <|> go []

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -246,7 +246,7 @@ equals = symbolic '='
 refArguments :: Parser [Argument Expr]
 refArguments = list <?> "argument list"
   where
-    list = parens $ commaSep $ namedArg <|> arg
+    list = parens $ commaSep $ try namedArg <|> arg
 
     namedArg = do
       name <- try $ ident <* equals

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -25,6 +25,7 @@ import qualified Data.CharSet as CS
 import qualified Data.CharSet.Unicode as CS
 import Data.Monoid ((<>))
 import qualified Data.Text.Prettyprint.Doc as PP
+import Data.Text.Prettyprint.Doc ((<+>))
 import qualified Test.QuickCheck as QC
 import Text.Trifecta hiding (ident)
 import Text.Parser.Expression
@@ -66,6 +67,11 @@ ident = token $ do
 data Argument a = Argument a            -- ^ Just a plain value
                 | NamedArgument Ident a -- ^ A named argument
                 deriving (Show)
+
+instance PP.Pretty a => PP.Pretty (Argument a) where
+  pretty v = case v of
+    Argument a -> PP.pretty a
+    NamedArgument i a -> PP.pretty i <+> "=" <+> PP.pretty a
 
 -- | An OpenSCAD geometry object
 data Object

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -200,9 +200,8 @@ instance PP.Pretty Object where
       <> (case moduleBody of
             [] -> PP.space <> PP.lbrace <> PP.rbrace
             _ -> PP.space
-              <> PP.enclose (PP.lbrace <> PP.line)
-                            (PP.line <> PP.rbrace)
-                   (PP.indent 2 . PP.vcat $ PP.pretty <$> moduleBody)
+              <> PP.enclose PP.lbrace (PP.line <> PP.rbrace)
+                   (PP.nest 2 $ PP.line <> PP.vsep (PP.pretty <$> moduleBody))
          )
     VarDef { varName, varValue } -> 
       PP.pretty varName

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -204,8 +204,8 @@ instance PP.Pretty Object where
          )
     VarDef { varName, varValue } -> 
       PP.pretty varName
-      <> PP.equals
-      <> PP.pretty varValue
+      <+> PP.equals
+      <+> PP.pretty varValue
       <> PP.semi
     FuncDef { funcName, funcArgs, funcBody } -> 
       "function"

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -47,18 +47,18 @@ newtype Ident = Ident String
               deriving (Show, Eq, Ord)
 
 instance PP.Pretty Ident where
-  pretty (Ident i) = PP.pretty i
+    pretty (Ident i) = PP.pretty i
 
 instance QC.Arbitrary Ident where
-  arbitrary = do
-    c <- QC.elements $ CS.toList ident1Chars
-    l <- QC.getSize
-    rest <- QC.vectorOf l . QC.elements $ CS.toList identChars
-    pure $ Ident (c:rest)
-  shrink (Ident s) = case s of
-    c1 : c2 : cs ->
-      fmap Ident $ [c1:cs] <> [c2:cs | c2 `CS.member` ident1Chars]
-    _ -> mempty
+    arbitrary = do
+        c <- QC.elements $ CS.toList ident1Chars
+        l <- QC.getSize
+        rest <- QC.vectorOf l . QC.elements $ CS.toList identChars
+        pure $ Ident (c:rest)
+    shrink (Ident s) = case s of
+        c1 : c2 : cs ->
+            fmap Ident $ [c1:cs] <> [c2:cs | c2 `CS.member` ident1Chars]
+        _ -> mempty
 
 identChars :: CS.CharSet
 identChars = CS.letter <> CS.decimalNumber <> CS.fromList "_"
@@ -79,16 +79,16 @@ data Argument a = Argument a            -- ^ Just a plain value
                 deriving (Show, Eq, Generic)
 
 instance QC.Arbitrary a => QC.Arbitrary (Argument a) where
-  arbitrary = QC.oneof
-    [ Argument <$> QC.arbitrary
-    , NamedArgument <$> QC.arbitrary <*> QC.arbitrary
-    ]
-  shrink = QC.genericShrink
+    arbitrary = QC.oneof
+        [ Argument <$> QC.arbitrary
+        , NamedArgument <$> QC.arbitrary <*> QC.arbitrary
+        ]
+    shrink = QC.genericShrink
 
 instance PP.Pretty a => PP.Pretty (Argument a) where
-  pretty v = case v of
-    Argument a -> PP.pretty a
-    NamedArgument i a -> PP.pretty i <+> "=" <+> PP.pretty a
+    pretty v = case v of
+        Argument a -> PP.pretty a
+        NamedArgument i a -> PP.pretty i <+> "=" <+> PP.pretty a
 
 -- | An OpenSCAD geometry object
 data Object
@@ -114,150 +114,152 @@ data Object
     deriving (Show, Generic, Eq)
 
 instance QC.Arbitrary Object where
-  arbitrary = QC.sized $ fix $ \rec n -> QC.oneof $
-    -- use quickcheck `sized` to keep sizes manageable
-    -- expressions are also resized with objects
-    [ do
-        -- amount of arguments
-        l <- QC.choose (0, n)
-        let n' = n `div` (2 * max l 1)
-        Module
-          <$> QC.arbitrary
-          <*> QC.vectorOf l (QC.resize n' QC.arbitrary)
-          <*> QC.resize n' QC.arbitrary
-    ] <> mconcat [
-    [ let n' = n `div` 2
-      in ForLoop <$> QC.arbitrary <*> QC.resize n' QC.arbitrary <*> rec n'
-    , do
-        -- amount of inner objects
-        l <- QC.choose (0, n)
-        let n' = n `div` max l 1
-        Objects <$> QC.vectorOf l (rec n')
-    , -- see `isAmbiguousIfElse`, nested if-else objects often must have an
-      -- `Object` in between
-      let n' = n `div` 3
-      in (If <$> QC.resize n' QC.arbitrary
-             <*> rec n'
-             <*> QC.resize n' QC.arbitrary
-         ) `QC.suchThat` (not . isAmbiguousIfElse)
-    , BackgroundMod <$> rec (n-1)
-    , DebugMod <$> rec (n-1)
-    , RootMod <$> rec (n-1)
-    , DisableMod <$> rec (n-1)
-    , do
-        -- amount of arguments
-        l <- QC.choose (0, n)
-        -- amount of inner objects
-        l' <- QC.choose (0, n)
-        let n' = n `div` (max l 1 * max l' 1)
-        ModuleDef
-          <$> QC.arbitrary
-          <*> QC.vectorOf l ((,) <$> QC.arbitrary <*> QC.resize n' QC.arbitrary)
-          <*> QC.vectorOf l' (rec n')
-    , VarDef <$> QC.arbitrary <*> QC.resize (n-1) QC.arbitrary
-    , FuncDef <$> QC.arbitrary
-              <*> QC.listOf QC.arbitrary
-              <*> QC.resize (n-1) QC.arbitrary
-    ] | n > 0
-    ]
-  shrink =
-    -- make sure the shrinks also satisfy the predicate for `If`-expressions
-    filter (not . isAmbiguousIfElse) . QC.genericShrink
+    arbitrary = QC.sized $ fix $ \rec n -> QC.oneof $
+        -- use quickcheck `sized` to keep sizes manageable
+        -- expressions are also resized with objects
+        [ do  -- amount of arguments
+              l <- QC.choose (0, n)
+              let n' = n `div` (2 * max l 1)
+              Module
+                  <$> QC.arbitrary
+                  <*> QC.vectorOf l (QC.resize n' QC.arbitrary)
+                  <*> QC.resize n' QC.arbitrary
+        ] <>
+        if n > 0
+        then
+            [ let n' = n `div` 2
+              in ForLoop <$> QC.arbitrary <*> QC.resize n' QC.arbitrary <*> rec n'
+            , do  -- amount of inner objects
+                  l <- QC.choose (0, n)
+                  let n' = n `div` max l 1
+                  Objects <$> QC.vectorOf l (rec n')
+            , -- see `isAmbiguousIfElse`, nested if-else objects often must have an
+              -- `Object` in between
+              let n' = n `div` 3
+              in (If
+                      <$> QC.resize n' QC.arbitrary
+                      <*> rec n'
+                      <*> QC.resize n' QC.arbitrary
+                ) `QC.suchThat` (not . isAmbiguousIfElse)
+            , BackgroundMod <$> rec (n-1)
+            , DebugMod <$> rec (n-1)
+            , RootMod <$> rec (n-1)
+            , DisableMod <$> rec (n-1)
+            , do  -- amount of arguments
+                  l <- QC.choose (0, n)
+                  -- amount of inner objects
+                  l' <- QC.choose (0, n)
+                  let n' = n `div` (max l 1 * max l' 1)
+                  ModuleDef
+                      <$> QC.arbitrary
+                      <*> QC.vectorOf l ((,) <$> QC.arbitrary <*> QC.resize n' QC.arbitrary)
+                      <*> QC.vectorOf l' (rec n')
+            , VarDef <$> QC.arbitrary <*> QC.resize (n-1) QC.arbitrary
+            , FuncDef
+                  <$> QC.arbitrary
+                  <*> QC.listOf QC.arbitrary
+                  <*> QC.resize (n-1) QC.arbitrary
+            ]
+        else []
+    shrink =
+        -- make sure the shrinks also satisfy the predicate for `If`-expressions
+        filter (not . isAmbiguousIfElse) . QC.genericShrink
 
 instance PP.Pretty Object where
-  pretty v = PP.group $ case v of
-    Module i args mBody ->
-      PP.pretty i
-      <> (if null args
-           then PP.lparen <> PP.rparen
-           else PP.align (PP.tupled (PP.pretty <$> args)))
-      <> case mBody of
-          Nothing -> PP.semi
-          -- for `Objects`, the `PP.nest` call is already done
-          Just os@(Objects _) -> PP.space <> PP.pretty os
-          Just o -> PP.nest 2 $ PP.line <> PP.pretty o
-    ForLoop i e o ->
-      "for"
-      <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
-      <> case o of
-          -- for `Objects`, the `PP.nest` call is already done
-          Objects _ -> PP.space <> PP.pretty o
-          _ -> PP.nest 2 $ PP.line <> PP.pretty o
-    Objects os -> 
-      PP.enclose PP.lbrace (PP.line <> PP.rbrace)
-      . PP.nest 2
-      $ PP.line <> PP.vsep (PP.pretty <$> os)
-    If c t me ->
-      "if"
-      <+> PP.parens (PP.pretty c)
-      <> (case t of
-            -- for `Objects`, the `PP.nest` call is already done
-            Objects _ -> PP.space <> PP.pretty t
-            _ -> PP.nest 2 (PP.line <> PP.pretty t)
-            )
-      <> maybe
-           mempty
-           (\e -> PP.line <> "else" <> PP.line <> PP.pretty e)
-           me
-    BackgroundMod o ->
-      "%" <> PP.pretty o
-    DebugMod o ->
-      "#" <> PP.pretty o
-    RootMod o ->
-      "!" <> PP.pretty o
-    DisableMod o ->
-      "*" <> PP.pretty o
-    ModuleDef { moduleName, moduleArgs, moduleBody } -> 
-      "module"
-      <+> PP.pretty moduleName
-      <> (if null moduleArgs
-           then PP.lparen <> PP.rparen
-           else PP.align . PP.tupled $ moduleArgs <&> \(i,mV) ->
-             PP.pretty i <> maybe mempty (\v -> PP.space <> PP.equals <+> PP.pretty v) mV
-         )
-      <> (case moduleBody of
-            [] -> PP.space <> PP.lbrace <> PP.rbrace
-            _ -> PP.space
-              <> PP.enclose PP.lbrace (PP.line <> PP.rbrace)
-                   (PP.nest 2 $ PP.line <> PP.vsep (PP.pretty <$> moduleBody))
-         )
-    VarDef { varName, varValue } -> 
-      PP.pretty varName
-      <> PP.nest 2
-          ( PP.line
-          <> PP.equals
-          <+> PP.group (PP.pretty varValue <> PP.semi))
-    FuncDef { funcName, funcArgs, funcBody } -> 
-      "function"
-      <+> PP.pretty funcName
-      <> (if null funcArgs
-           then PP.lparen <> PP.rparen
-           else PP.align . PP.tupled $ PP.pretty <$> funcArgs
-         )
-      <> PP.nest 2
-          (PP.line
-          <> PP.equals
-          <+> PP.pretty funcBody
-          <> PP.semi)
+    pretty v = PP.group $ case v of
+        Module i args mBody ->
+            PP.pretty i
+            <> (if null args
+                then PP.lparen <> PP.rparen
+                else PP.align (PP.tupled (PP.pretty <$> args)))
+            <> case mBody of
+                Nothing -> PP.semi
+                -- for `Objects`, the `PP.nest` call is already done
+                Just os@(Objects _) -> PP.space <> PP.pretty os
+                Just o -> PP.nest 2 $ PP.line <> PP.pretty o
+        ForLoop i e o ->
+            "for"
+            <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
+            <> case o of
+                -- for `Objects`, the `PP.nest` call is already done
+                Objects _ -> PP.space <> PP.pretty o
+                _ -> PP.nest 2 $ PP.line <> PP.pretty o
+        Objects os -> 
+            PP.enclose PP.lbrace (PP.line <> PP.rbrace)
+            . PP.nest 2
+            $ PP.line <> PP.vsep (PP.pretty <$> os)
+        If c t me ->
+            "if"
+            <+> PP.parens (PP.pretty c)
+            <> (case t of
+                  -- for `Objects`, the `PP.nest` call is already done
+                  Objects _ -> PP.space <> PP.pretty t
+                  _ -> PP.nest 2 (PP.line <> PP.pretty t)
+                  )
+            <> maybe
+                mempty
+                (\e -> PP.line <> "else" <> PP.line <> PP.pretty e)
+                me
+        BackgroundMod o ->
+            "%" <> PP.pretty o
+        DebugMod o ->
+            "#" <> PP.pretty o
+        RootMod o ->
+            "!" <> PP.pretty o
+        DisableMod o ->
+            "*" <> PP.pretty o
+        ModuleDef { moduleName, moduleArgs, moduleBody } -> 
+            "module"
+            <+> PP.pretty moduleName
+            <> (if null moduleArgs
+                then PP.lparen <> PP.rparen
+                else PP.align . PP.tupled $ moduleArgs <&> \(i,mV) ->
+                  PP.pretty i <> maybe mempty (\v -> PP.space <> PP.equals <+> PP.pretty v) mV
+              )
+            <> (case moduleBody of
+                  [] -> PP.space <> PP.lbrace <> PP.rbrace
+                  _ -> PP.space
+                    <> PP.enclose PP.lbrace (PP.line <> PP.rbrace)
+                        (PP.nest 2 $ PP.line <> PP.vsep (PP.pretty <$> moduleBody))
+               )
+        VarDef { varName, varValue } -> 
+            PP.pretty varName
+            <> PP.nest 2
+                ( PP.line
+                <> PP.equals
+                <+> PP.group (PP.pretty varValue <> PP.semi))
+        FuncDef { funcName, funcArgs, funcBody } -> 
+            "function"
+            <+> PP.pretty funcName
+            <> (if null funcArgs
+                then PP.lparen <> PP.rparen
+                else PP.align . PP.tupled $ PP.pretty <$> funcArgs
+               )
+            <> PP.nest 2
+                (PP.line
+                <> PP.equals
+                <+> PP.pretty funcBody
+                <> PP.semi)
 
 -- | Is this `Object` an ambiguous if-else expression?
 -- This occurs if an if-else contains a plain if without any braces between it.
 -- Then the else is parsed as belonging to the inner if.
 isAmbiguousIfElse :: Object -> Bool
 isAmbiguousIfElse v = case v of
-  If _ t (Just _) -> 
-    let f e = case e of
-          If _ _ Nothing -> True
-          If _ _ (Just e') -> f e'
-          ForLoop _ _ o -> f o
-          BackgroundMod o -> f o
-          DebugMod o -> f o
-          RootMod o -> f o
-          DisableMod o -> f o
-          Module _ _ (Just o) -> f o
-          _ -> False
-    in f t
-  _ -> False
+    If _ t (Just _) -> 
+        let f e =
+                case e of
+                    If _ _ Nothing -> True
+                    If _ _ (Just e') -> f e'
+                    ForLoop _ _ o -> f o
+                    BackgroundMod o -> f o
+                    DebugMod o -> f o
+                    RootMod o -> f o
+                    DisableMod o -> f o
+                    Module _ _ (Just o) -> f o
+                    _ -> False
+        in f t
+    _ -> False
 
 -- | An OpenSCAD expression
 data Expr
@@ -289,141 +291,146 @@ data Expr
     deriving (Show, Eq, Generic)
 
 instance QC.Arbitrary Expr where
-  arbitrary =
-    -- use quickcheck `sized` to keep sizes manageable
-    -- guide expression generation to efficiently get operators with correct precedence/associativity
-    -- p = current precedence
-    -- mAssoc = current associativity
-    -- n = size
-    QC.sized $ fix (\rec p mAssoc n ->
-      let
-        -- simple non-recursive terms (parsed by `term`)
-        simpleTerms
-          = [ EBool <$> QC.arbitrary
-            , EString <$> QC.arbitrary
-            , EVar <$> QC.arbitrary
-            , ENum <$> QC.arbitrary
-            ]
-        -- recursive terms (parsed by `term`)
-        -- recursion resets precedence/assoc, this by simply calling `arbitrary`
-        -- instead of `rec`
-        recursiveTerms
-          = [ EParen <$> QC.resize (n-1) QC.arbitrary
-            , do
-                l <- QC.choose (0,n)
-                let n' = n `div` max 1 l
-                EVec <$> QC.vectorOf l (QC.resize n' QC.arbitrary)
-            , ERange <$> QC.resize (n - 1) QC.arbitrary
-            , do
-                l <- QC.choose (0,n)
-                let n' = n `div` max 1 l
-                EFunc <$> QC.arbitrary <*> QC.vectorOf l (QC.resize n' QC.arbitrary)
-            , let n' = n `div` 2
-              in EIndex <$> QC.resize n' (QC.oneof $ simpleTerms <> recursiveTerms)
-                        <*> QC.resize n' QC.arbitrary
-            ]
-        -- operators (parsed by `expression`)
-        ops
-          = [ let n' = n `div` 3
-              in ETernary <$> QC.resize n' (QC.oneof simpleTerms)
-                          <*> QC.resize n' QC.arbitrary
-                          <*> QC.resize n' QC.arbitrary
-            | p == 0 -- don't mix with other operators
-            ] ++ catMaybes -- generate operators with higher precedence
-            [ genOp p' op
-            | (p',ops) <- zip (reverse [1 .. length opTable]) opTable
-            , op <- ops
-            ]
-          where
-            isNegatedNum e = case e of
-              ENegate e' ->
-                let f e'' = case e'' of
-                      ENum _ -> True
-                      EIndex e''' _ -> f e'''
-                      _ -> False
-                in f e'
-              _ -> False
-            isNegativeNum e = case e of
-              ENum d -> d < 0
-              EIndex e' _ -> isNegativeNum e'
-              _ -> False
-            genOp p' op = case op of
-              -- NOTE: this generation mechanism relies on the fact that unary
-              -- operators have a higher precedence than binary operators
-              Prefix (OperatorParser c _)
-                | p' > p ->
-                  -- inner operators should have higher precedence
-                  Just $ (c <$> (rec (p'+1) Nothing (n - 1))
-                          -- prefix + sign is not supported
-                          `QC.suchThat` (not . isNegativeNum)
-                         -- negation of num is parsed as sign
-                         ) `QC.suchThat` (not . isNegatedNum)
-              Postfix (OperatorParser c _)
-                | p' > p ->
-                  -- inner operators should have higher precedence
-                  Just $ c <$> rec (p'+1) Nothing (n - 1)
-              Infix (OperatorParser c _) assoc'
-                | p' > p || p' == p && maybe True (== assoc') mAssoc ->
-                  -- inner operators should have higher precedence
-                  -- or equal precedence and same associativity
-                  let n' = n `div` 2
-                  in Just $ c <$> rec (p'+1) (Just assoc') n'
-                              <*> rec (p'+1) (Just assoc') n' 
-              _ -> Nothing
-      in if n <= 0
-          then QC.oneof simpleTerms
-          else QC.oneof $ recursiveTerms <> ops   
-    ) 0 Nothing
-  shrink = QC.genericShrink
+    arbitrary =
+        -- use quickcheck `sized` to keep sizes manageable
+        -- guide expression generation to efficiently get operators with correct
+        -- precedence/associativity
+        --
+        -- p = current precedence
+        -- mAssoc = current associativity
+        -- n = size
+        QC.sized $ fix (\rec p mAssoc n ->
+            let
+                -- simple non-recursive terms (parsed by `term`)
+                simpleTerms =
+                    [ EBool <$> QC.arbitrary
+                    , EString <$> QC.arbitrary
+                    , EVar <$> QC.arbitrary
+                    , ENum <$> QC.arbitrary
+                    ]
+                -- recursive terms (parsed by `term`)
+                -- recursion resets precedence/assoc, this by simply calling `arbitrary`
+                -- instead of `rec`
+                recursiveTerms =
+                    [ EParen <$> QC.resize (n-1) QC.arbitrary
+                    , do  l <- QC.choose (0,n)
+                          let n' = n `div` max 1 l
+                          EVec <$> QC.vectorOf l (QC.resize n' QC.arbitrary)
+                    , ERange <$> QC.resize (n - 1) QC.arbitrary
+                    , do  l <- QC.choose (0,n)
+                          let n' = n `div` max 1 l
+                          EFunc <$> QC.arbitrary <*> QC.vectorOf l (QC.resize n' QC.arbitrary)
+                    , let n' = n `div` 2
+                      in EIndex <$> QC.resize n' (QC.oneof $ simpleTerms <> recursiveTerms)
+                                <*> QC.resize n' QC.arbitrary
+                    ]
+                -- operators (parsed by `expression`)
+                ops =
+                    [ let n' = n `div` 3
+                      in ETernary <$> QC.resize n' (QC.oneof simpleTerms)
+                                  <*> QC.resize n' QC.arbitrary
+                                  <*> QC.resize n' QC.arbitrary
+                    | p == 0 -- don't mix with other operators
+                    ] ++ catMaybes -- generate operators with higher precedence
+                    [ genOp p' op
+                    | (p',ops) <- zip (reverse [1 .. length opTable]) opTable
+                    , op <- ops
+                    ]
+                  where
+                    isNegatedNum e = case e of
+                        ENegate e' ->
+                            let f e'' = case e'' of
+                                    ENum _ -> True
+                                    EIndex e''' _ -> f e'''
+                                    _ -> False
+                            in f e'
+                        _ -> False
+                    isNegativeNum e = case e of
+                        ENum d -> d < 0
+                        EIndex e' _ -> isNegativeNum e'
+                        _ -> False
+                    genOp p' op = case op of
+                        -- NOTE: this generation mechanism relies on the
+                        -- assumption that unary operators have a higher
+                        -- precedence than binary operators
+                        Prefix (OperatorParser c _)
+                            | p' > p ->
+                                -- inner operators should have higher precedence
+                                Just $ (c <$> (rec (p'+1) Nothing (n - 1))
+                                        -- prefix + sign is not supported
+                                        `QC.suchThat` (not . isNegativeNum)
+                                      -- negation of num is parsed as sign
+                                      ) `QC.suchThat` (not . isNegatedNum)
+                        Postfix (OperatorParser c _)
+                            | p' > p ->
+                                -- inner operators should have higher precedence
+                                Just $ c <$> rec (p'+1) Nothing (n - 1)
+                        Infix (OperatorParser c _) assoc'
+                            | p' > p || p' == p && maybe True (== assoc') mAssoc ->
+                                -- inner operators should have higher precedence
+                                -- or equal precedence and same associativity
+                                let n' = n `div` 2
+                                in Just $ c <$> rec (p'+1) (Just assoc') n'
+                                            <*> rec (p'+1) (Just assoc') n' 
+                        _ -> Nothing
+            in if n <= 0
+                then QC.oneof simpleTerms
+                else QC.oneof $ recursiveTerms <> ops   
+        ) 0 Nothing
+    shrink = QC.genericShrink
 
 instance PP.Pretty Expr where
-  pretty e = case e of
-    EVar i -> PP.pretty i
-    EIndex e1 idx -> PP.pretty e1 <> PP.brackets (PP.pretty idx)
-    ENum d -> PP.pretty d
-    EVec es ->
-      if null es
-        then PP.lbracket <> PP.rbracket
-        else PP.align . PP.list $ PP.pretty <$> es
-    ERange r -> PP.pretty r
-    EString s ->
-      let escape c acc =
-            case lookup c escapedChars of
-              Just c' -> '\\' : c' : acc
-              Nothing -> c : acc
-      in PP.dquotes $ PP.pretty (foldr' escape "" s)
-    EBool b -> case b of
-      True -> "true"
-      False -> "false"
-    EFunc name args ->
-      PP.pretty name
-      <> (if null args
-           then PP.lparen <> PP.rparen
-           else PP.align . PP.tupled $ (PP.pretty <$> args)
-         )
-    ENegate e1 -> prefix "-" e1
-    EPlus e1 e2 -> binary "+" e1 e2
-    EMinus e1 e2 -> binary "-" e1 e2
-    EMult e1 e2 -> binary "*" e1 e2
-    EDiv e1 e2 -> binary "/" e1 e2
-    EMod e1 e2 -> binary "%" e1 e2
-    EEquals e1 e2 -> binary "==" e1 e2
-    ENotEquals e1 e2 -> binary "!=" e1 e2
-    EGT e1 e2 -> binary ">" e1 e2
-    EGE e1 e2 -> binary ">=" e1 e2
-    ELT e1 e2 -> binary "<" e1 e2
-    ELE e1 e2 -> binary "<=" e1 e2
-    ENot e1 -> prefix "!"  e1
-    EOr e1 e2 -> binary "||" e1 e2
-    EAnd e1 e2 -> binary "&&" e1 e2
-    ETernary e1 e2 e3 -> ternary "?" ":" e1 e2 e3
-    EParen e1 -> PP.group . PP.align . PP.enclose (PP.flatAlt "( " "(") (PP.flatAlt " )" ")") $ PP.pretty e1
-   where
-    prefix op e1 = op <> PP.pretty e1
-    binary op e1 e2 = PP.align $ PP.pretty e1 <> PP.line <> op <+> PP.pretty e2
-    ternary op1 op2 e1 e2 e3 =
-      let f s = PP.pretty e1 <> s <> op1 <+> PP.pretty e2 <> s <> op2 <+> PP.pretty e3
-      in PP.group $ PP.align (f PP.line) `PP.flatAlt` f PP.space
+    pretty e = case e of
+        EVar i -> PP.pretty i
+        EIndex e1 idx -> PP.pretty e1 <> PP.brackets (PP.pretty idx)
+        ENum d -> PP.pretty d
+        EVec es ->
+            if null es
+            then PP.lbracket <> PP.rbracket
+            else PP.align . PP.list $ PP.pretty <$> es
+        ERange r -> PP.pretty r
+        EString s ->
+            let escape c acc =
+                    case lookup c escapedChars of
+                        Just c' -> '\\' : c' : acc
+                        Nothing -> c : acc
+            in PP.dquotes $ PP.pretty (foldr' escape "" s)
+        EBool b -> case b of
+            True -> "true"
+            False -> "false"
+        EFunc name args ->
+            PP.pretty name
+            <> (if null args
+                then PP.lparen <> PP.rparen
+                else PP.align . PP.tupled $ (PP.pretty <$> args)
+               )
+        ENegate e1 -> prefix "-" e1
+        EPlus e1 e2 -> binary "+" e1 e2
+        EMinus e1 e2 -> binary "-" e1 e2
+        EMult e1 e2 -> binary "*" e1 e2
+        EDiv e1 e2 -> binary "/" e1 e2
+        EMod e1 e2 -> binary "%" e1 e2
+        EEquals e1 e2 -> binary "==" e1 e2
+        ENotEquals e1 e2 -> binary "!=" e1 e2
+        EGT e1 e2 -> binary ">" e1 e2
+        EGE e1 e2 -> binary ">=" e1 e2
+        ELT e1 e2 -> binary "<" e1 e2
+        ELE e1 e2 -> binary "<=" e1 e2
+        ENot e1 -> prefix "!"  e1
+        EOr e1 e2 -> binary "||" e1 e2
+        EAnd e1 e2 -> binary "&&" e1 e2
+        ETernary e1 e2 e3 -> ternary "?" ":" e1 e2 e3
+        EParen e1 ->
+            PP.group
+            . PP.align
+            . PP.enclose (PP.flatAlt "( " "(") (PP.flatAlt " )" ")")
+            $ PP.pretty e1
+      where
+        prefix op e1 = op <> PP.pretty e1
+        binary op e1 e2 = PP.align $ PP.pretty e1 <> PP.line <> op <+> PP.pretty e2
+        ternary op1 op2 e1 e2 e3 =
+            let f s = PP.pretty e1 <> s <> op1 <+> PP.pretty e2 <> s <> op2 <+> PP.pretty e3
+            in PP.group $ PP.align (f PP.line) `PP.flatAlt` f PP.space
 
 -- | @Range start end step@ denotes a list starting at @start@ and
 -- stopping at @end@ with increments of @step@.
@@ -431,17 +438,17 @@ data Range a = Range a a (Maybe a)
              deriving (Show, Eq, Generic1)
 
 instance QC.Arbitrary a => QC.Arbitrary (Range a) where
-  arbitrary = Range <$> QC.arbitrary <*> QC.arbitrary <*> QC.arbitrary
+    arbitrary = Range <$> QC.arbitrary <*> QC.arbitrary <*> QC.arbitrary
 
 instance PP.Pretty a => PP.Pretty (Range a) where
-  pretty (Range start stop step) =
-    PP.align
-    . PP.group
-    . PP.encloseSep (PP.flatAlt "[ " "[")
-                    (PP.flatAlt " ]" "]")
-                    (PP.flatAlt ": " ":")
-    . fmap PP.pretty
-    $ [start, stop] <> maybe [] pure step
+    pretty (Range start stop step) =
+        PP.align
+        . PP.group
+        . PP.encloseSep (PP.flatAlt "[ " "[")
+                        (PP.flatAlt " ]" "]")
+                        (PP.flatAlt ": " ":")
+        . fmap PP.pretty
+        $ [start, stop] <> maybe [] pure step
 
 sepByTill :: Parser delim -> Parser end -> Parser a -> Parser [a]
 sepByTill delim end parser = (end *> return []) <|> go []
@@ -495,16 +502,16 @@ double' = notIdent $
 fractExponent :: forall m. TokenParsing m => m (Integer -> Sci.Scientific)
 fractExponent = (\fract expo n -> (fromInteger n + fract) * expo) <$> fraction <*> option 1 exponent'
             <|> (\expo n -> fromInteger n * expo) <$> exponent'
- where
-  fraction :: m Sci.Scientific
-  fraction = foldl' op 0 <$> (char '.' *> (some digit <?> "fraction"))
+  where
+    fraction :: m Sci.Scientific
+    fraction = foldl' op 0 <$> (char '.' *> (some digit <?> "fraction"))
 
-  op f d = f + Sci.scientific (fromIntegral (digitToInt d)) (Sci.base10Exponent f - 1)
+    op f d = f + Sci.scientific (fromIntegral (digitToInt d)) (Sci.base10Exponent f - 1)
 
-  exponent' :: m Sci.Scientific
-  exponent' = ((\f e -> power (f e)) <$ oneOf "eE" <*> sign <*> (decimal <?> "exponent")) <?> "exponent"
+    exponent' :: m Sci.Scientific
+    exponent' = ((\f e -> power (f e)) <$ oneOf "eE" <*> sign <*> (decimal <?> "exponent")) <?> "exponent"
 
-  power = Sci.scientific 1 . fromInteger
+    power = Sci.scientific 1 . fromInteger
 
 sign :: (Num a, TokenParsing m) => m (a -> a)
 sign =
@@ -517,32 +524,32 @@ sign =
 -- E.g. the quote '"' character gets parsed/printed as `\"`.
 escapedChars :: [(Char, Char)]
 escapedChars =
-  [ ('\\' , '\\')
-  , ('"' , '"')
-  , ('\t' , 't')
-  , ('\n' , 'n')
-  , ('\r' , 'r')
-  ]
+    [ ('\\' , '\\')
+    , ('"' , '"')
+    , ('\t' , 't')
+    , ('\n' , 'n')
+    , ('\r' , 'r')
+    ]
 
 -- | Parse a term of an expression
 term :: Parser Expr
 term = do
-  e <- choice
-    [ try funcRef
-    , ERange <$> try range
-    , EVec <$> brackets (sepEndBy expression (some comma))
-    , EString <$> stringLit
-    , EBool <$> choice [ keyword "true" >> return True
-                       , keyword "false" >> return False
-                       ]
-    , EVar <$> ident
-    , ENum <$> double'
-    , EParen <$> parens expression
-    ]
-  -- build all `EIndex` expressions here
-  idxs <- many $ brackets expression <?> "index expression"
-  spaces
-  return $ foldl' EIndex e idxs
+    e <- choice
+        [ try funcRef
+        , ERange <$> try range
+        , EVec <$> brackets (sepEndBy expression (some comma))
+        , EString <$> stringLit
+        , EBool <$> choice [ keyword "true" >> return True
+                          , keyword "false" >> return False
+                          ]
+        , EVar <$> ident
+        , ENum <$> double'
+        , EParen <$> parens expression
+        ]
+    -- build all `EIndex` expressions here
+    idxs <- many $ brackets expression <?> "index expression"
+    spaces
+    return $ foldl' EIndex e idxs
   where
     funcRef = do
       name <- ident
@@ -586,9 +593,9 @@ expression =
 
 -- | Internal data structure to keep both the operator and its parser 
 data OperatorParser a = OperatorParser
-  { opFun :: a
-  , opParser :: Parser ()
-  }
+    { opFun :: a
+    , opParser :: Parser ()
+    }
 
 opTable :: [[Operator OperatorParser Expr]]
 opTable =
@@ -709,18 +716,18 @@ data TopLevel = TopLevelScope Object
               deriving (Show, Eq, Generic)
 
 instance QC.Arbitrary TopLevel where
-  arbitrary = QC.oneof
-    [ TopLevelScope <$> QC.arbitrary
-    , UseDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
-    , IncludeDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
-    ]
-  shrink = QC.genericShrink
+    arbitrary = QC.oneof
+        [ TopLevelScope <$> QC.arbitrary
+        , UseDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
+        , IncludeDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
+        ]
+    shrink = QC.genericShrink
 
 instance PP.Pretty TopLevel where
-  pretty v = case v of
-    TopLevelScope o -> PP.pretty o
-    IncludeDirective s -> "include" <> PP.angles (PP.pretty s)
-    UseDirective s -> "use" <> PP.angles (PP.pretty s)
+    pretty v = case v of
+        TopLevelScope o -> PP.pretty o
+        IncludeDirective s -> "include" <> PP.angles (PP.pretty s)
+        UseDirective s -> "use" <> PP.angles (PP.pretty s)
 
 -- | Parse the top-level definitions of an OpenSCAD source file
 topLevel :: Parser TopLevel

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -163,7 +163,10 @@ instance PP.Pretty Object where
       <> PP.parens (PP.pretty i <+> "=" <+> PP.pretty e)
       <> PP.nest 2 (PP.softline <> PP.pretty o)
     Objects os -> 
-      PP.braces . PP.vsep $ PP.pretty <$> os
+      PP.enclose (PP.lbrace <> PP.hardline) (PP.hardline <> PP.rbrace) 
+        . PP.indent 2
+        . PP.vcat
+        $ PP.pretty <$> os
     If c t me ->
       "if"
       <+> PP.parens (PP.pretty c)

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -356,7 +356,7 @@ instance QC.Arbitrary Expr where
                         Prefix (OperatorParser c _)
                             | p' > p ->
                                 -- inner operators should have higher precedence
-                                Just $ (c <$> (rec (p'+1) Nothing (n - 1))
+                                Just $ (c <$> rec (p'+1) Nothing (n - 1)
                                         -- prefix + sign is not supported
                                         `QC.suchThat` (not . isNegativeNum)
                                       -- negation of num is parsed as sign
@@ -718,8 +718,8 @@ data TopLevel = TopLevelScope Object
 instance QC.Arbitrary TopLevel where
     arbitrary = QC.oneof
         [ TopLevelScope <$> QC.arbitrary
-        , UseDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
-        , IncludeDirective <$> (QC.arbitrary `QC.suchThat` all (/= '>'))
+        , UseDirective <$> (QC.arbitrary `QC.suchThat` notElem '>')
+        , IncludeDirective <$> (QC.arbitrary `QC.suchThat` notElem '>')
         ]
     shrink = QC.genericShrink
 

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -27,6 +28,7 @@ import qualified Data.CharSet.Unicode as CS
 import Data.Monoid ((<>))
 import qualified Data.Text.Prettyprint.Doc as PP
 import Data.Text.Prettyprint.Doc ((<+>))
+import GHC.Generics (Generic(..))
 import qualified Test.QuickCheck as QC
 import Text.Trifecta hiding (ident)
 import Text.Parser.Expression
@@ -67,7 +69,14 @@ ident = token $ do
 -- | An item in an argument list
 data Argument a = Argument a            -- ^ Just a plain value
                 | NamedArgument Ident a -- ^ A named argument
-                deriving (Show)
+                deriving (Show, Eq, Generic)
+
+instance QC.Arbitrary a => QC.Arbitrary (Argument a) where
+  arbitrary = QC.oneof
+    [ Argument <$> QC.arbitrary
+    , NamedArgument <$> QC.arbitrary <*> QC.arbitrary
+    ]
+  shrink = QC.genericShrink
 
 instance PP.Pretty a => PP.Pretty (Argument a) where
   pretty v = case v of

--- a/src/Language/OpenSCAD.hs
+++ b/src/Language/OpenSCAD.hs
@@ -12,6 +12,7 @@ module Language.OpenSCAD
     , Object(..)
       -- * Expressions
     , Expr(..)
+    , expression
     , Argument(..)
     , Range(..)
     ) where


### PR DESCRIPTION
I've made a pretty printer for the OpenSCAD syntax tree, loosely based on #3 and on my BrechtSerckx/OpenSCAD fork.
This PR also includes roundtrip tests with QuickCheck and some additional unit tests.

To do:
- [x] Format code (@bgamari what formatter is used or would you prefer?)